### PR TITLE
add overload to getReferenceSeq

### DIFF
--- a/bin/sam-coverage-depth.py
+++ b/bin/sam-coverage-depth.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 from itertools import repeat
 from contextlib import redirect_stdout
-from typing import Collection, Any
+from typing import Collection, Any, overload
 
 from dark.fasta import FastaReads
 from dark.sam import samfile, samReferenceLengths
@@ -185,6 +185,12 @@ def getReferenceId(
 
     return referenceId
 
+
+@overload
+def getReferenceSeq(fasta: None, referenceId: str) -> None: ...
+
+@overload
+def getReferenceSeq(fasta: str, referenceId: str) -> str: ...
 
 def getReferenceSeq(fasta: str | None, referenceId: str) -> str | None:
     """


### PR DESCRIPTION
This is correct solution for typing this. The `TypeVar` was wrong, not just because of the issue with `None`, but actually because of the other case. Typing `fasta` as `str` allows you to pass any subtype of `str`, however the return type in this case is always `str`, so it's incorrect to say the return type is the same as the argument type for this case. (Even though it probably always will be in practice, I don't know any `str` subtypes.)